### PR TITLE
Implement visualization for when blocks

### DIFF
--- a/libs/core/chibiclip.ts
+++ b/libs/core/chibiclip.ts
@@ -66,8 +66,6 @@ namespace ChibiClip {
       pinToEventHandlers[i] = empty;
     }
 
-    console.log('init forever loop');
-
     // Add a forever loop in the namespace to poll for pin event changes.
     basic.forever(() => {
       for (let pinIndex = 0; pinIndex < TOTAL_GPIO_PINS; pinIndex++) {
@@ -284,8 +282,6 @@ namespace ChibiClip {
         pinToEventHandlers[pinIndex].onLow = handler;
         break;
     }
-    console.log('setting event handlers');
-    console.log(pinToEventHandlers[pinIndex]);
   }
 }
 

--- a/sim/visuals/chibiclip.ts
+++ b/sim/visuals/chibiclip.ts
@@ -38,19 +38,21 @@ const TEXT_X_OFFSET = X_OFFSET;
 const TEXT_X_DISTANCE = SPACING;
 
 const WIRE_WIDTH = 20;
-const WIRE_DISTANCE = 150;
-const SWITCH_DISTANCE = 60;
+const WIRE_DISTANCE = 120;
+const SWITCH_DISTANCE = 50;
 const SWITCH_GAP = 40;
 const WIRE_COLOR = "gray";
 const GAP_OFF_COLOR = "transparent";
 const GAP_ON_COLOR = WIRE_COLOR;
 
-const SWITCH_TOGGLES_Y = CLIP_HEIGHT + WIRE_DISTANCE + WIRE_WIDTH + 50;
+const SWITCH_TOGGLES_Y = CLIP_HEIGHT + WIRE_DISTANCE + WIRE_WIDTH + 40;
 const SWITCH_TOGGLES_GAP = 20;
 const SWITCH_TOGGLE_HEIGHT = RECT_HEIGHT;
 const SWITCH_TOGGLE_WIDTH = RECT_WIDTH;
 const SWITCH_OFF_COLOR = "gainsboro";
 const SWITCH_ON_COLOR = "green";
+
+const LED_TOGGLES_Y = SWITCH_TOGGLES_Y
 
 namespace pxsim.visuals {
   function createSvgElement(tagName: string) {

--- a/sim/visuals/chibiclip.ts
+++ b/sim/visuals/chibiclip.ts
@@ -46,7 +46,10 @@ const GAP_OFF_COLOR = "transparent";
 const GAP_ON_COLOR = WIRE_COLOR;
 
 const SWITCH_TOGGLES_Y = CLIP_HEIGHT + WIRE_DISTANCE + WIRE_WIDTH + 100;
-const SWITCH_GROUP_CLASS_NAME = "all-toggles";
+const SWITCH_GROUP_CLASS_NAME = "all-switch-toggles";
+
+const LIGHT_TOGGLES_Y = SWITCH_TOGGLES_Y + 100;
+const LIGHT_GROUP_CLASS_NAME = "all-light-toggles";
 
 const TOGGLES_GAP = 20;
 const TOGGLE_HEIGHT = RECT_WIDTH;
@@ -155,7 +158,8 @@ namespace pxsim.visuals {
     }
 
     // Add toggles add/remove switches
-    group.append(addSwitchToggles(SWITCH_TOGGLES_Y, SWITCH_GROUP_CLASS_NAME, "Add Switch"));
+    group.append(addToggles(SWITCH_TOGGLES_Y, SWITCH_GROUP_CLASS_NAME, "Add Switch"));
+    group.append(addToggles(LIGHT_TOGGLES_Y, LIGHT_GROUP_CLASS_NAME, "Add Light"));
 
     return root.firstElementChild as SVGAElement;
   }
@@ -264,7 +268,7 @@ namespace pxsim.visuals {
     return group;
   }
 
-  function addSwitchToggles(yOffset: number, groupClassName: string, label: string) {
+  function addToggles(yOffset: number, groupClassName: string, label: string) {
     const group = createSvgElement("g");
     group.classList.add(groupClassName);
 
@@ -303,7 +307,7 @@ namespace pxsim.visuals {
     );
     labelText.setAttribute(
       "y",
-      `${SWITCH_TOGGLES_Y + TOGGLES_GAP + TOGGLE_HEIGHT / 2 + 4}`
+      `${overallYOffset + TOGGLES_GAP + TOGGLE_HEIGHT / 2 + 4}`
     );
     labelText.setAttribute("textAnchor", "middle");
     labelText.innerHTML = `${pinIndex}`;

--- a/sim/visuals/chibiclip.ts
+++ b/sim/visuals/chibiclip.ts
@@ -255,23 +255,18 @@ namespace pxsim.visuals {
     group.setAttribute("id", `${getWireIdName(i, SWITCH_GROUP_CLASS_NAME)}`);
     group.classList.add("circuit");
 
-    const widthOffset = (RECT_WIDTH - WIRE_WIDTH) / 2;
-    const startingX = widthOffset + RECT_X_OFFSET + RECT_X_DISTANCE * i;
+    const xOffset = RECT_X_OFFSET + RECT_WIDTH / 2
+    const startingX = xOffset + RECT_X_DISTANCE * i;
     const bottomOfClipY = CLIP_HEIGHT;
 
-    const initialRect = createSvgElement("line");
-    initialRect.setAttribute("x1", `${startingX}`);
-    initialRect.setAttribute("y1", `${bottomOfClipY}`);
-    initialRect.setAttribute("x2", `${startingX}`);
-    initialRect.setAttribute(
-      "y2",
-      `${bottomOfClipY + SWITCH_OFF_INITIAL_WIRE_HEIGHT}`
-    );
-    initialRect.setAttribute("stroke", "black");
-    initialRect.setAttribute("stroke-width", `${WIRE_WIDTH}`);
-    initialRect.classList.add("wire");
-    group.append(initialRect);
+    // Draw the initial line before the gap.
+    const initialLinePath = createSvgElement("path");
+    const initialLineD = `M ${startingX} ${bottomOfClipY} V ${bottomOfClipY + SWITCH_OFF_INITIAL_WIRE_HEIGHT}`
+    initialLinePath.setAttribute("d", initialLineD);
+    initialLinePath.classList.add("new-wire");
+    group.append(initialLinePath);
 
+    // Draw the switch in the off state
     const gapButton = createSvgElement("rect");
     gapButton.setAttribute("x", `${startingX}`);
     gapButton.setAttribute(
@@ -284,37 +279,25 @@ namespace pxsim.visuals {
     gapButton.setAttribute("data-pin-index", `${i}`);
     group.append(gapButton);
 
-    const polygon = createSvgElement("polygon");
-    polygon.classList.add("wire");
+    // Draw the remaining line.
+    const remainingLinePath = createSvgElement("path");
+    const remainingY1 = bottomOfClipY + SWITCH_OFF_INITIAL_WIRE_HEIGHT + SWITCH_GAP;
+    let remainingLineD = `M ${startingX} ${remainingY1} `;
 
-    const x1 = startingX;
-    const y1 = bottomOfClipY + SWITCH_OFF_INITIAL_WIRE_HEIGHT + SWITCH_GAP;
+    // 1. Draw the downward stroke
+    remainingLineD += `V ${CLIP_HEIGHT + SWITCH_WIRE_HEIGHT} `;
 
-    const x2 = x1 + WIRE_WIDTH;
-    const y2 = y1;
+    // 2. Draw the horizontal stroke 
+    const powerPinStartingX = xOffset + RECT_X_DISTANCE * POWER_PIN_INDEX;
+    remainingLineD += `H ${powerPinStartingX} `;
 
-    const x3 = x2;
-    const y3 = y2 + (wireHeight - SWITCH_OFF_INITIAL_WIRE_HEIGHT - SWITCH_GAP);
+    // 3. Draw the remaining vertical stroke 
+    remainingLineD += `V ${bottomOfClipY} `;
 
-    const powerPinStartingX = RECT_X_OFFSET + RECT_X_DISTANCE * POWER_PIN_INDEX;
-    const x4 = powerPinStartingX + widthOffset;
-    const y4 = y3;
+    remainingLinePath.setAttribute("d", remainingLineD);
+    remainingLinePath.classList.add("new-wire");
+    group.append(remainingLinePath);
 
-    const x5 = x4;
-    const y5 = bottomOfClipY;
-
-    const x6 = x5 + WIRE_WIDTH;
-    const y6 = y5;
-
-    const x7 = x6;
-    const y7 = y3 + WIRE_WIDTH;
-
-    const x8 = x1;
-    const y8 = y7;
-
-    const points = `${x1},${y1} ${x2},${y2} ${x3},${y3} ${x4},${y4} ${x5},${y5} ${x6},${y6} ${x7},${y7} ${x8},${y8}`;
-    polygon.setAttribute("points", points);
-    group.append(polygon);
     return group;
   }
 

--- a/sim/visuals/chibiclip.ts
+++ b/sim/visuals/chibiclip.ts
@@ -46,11 +46,13 @@ const GAP_OFF_COLOR = "transparent";
 const GAP_ON_COLOR = WIRE_COLOR;
 
 const SWITCH_TOGGLES_Y = CLIP_HEIGHT + WIRE_DISTANCE + WIRE_WIDTH + 100;
-const SWITCH_TOGGLES_GAP = 20;
-const SWITCH_TOGGLE_HEIGHT = RECT_WIDTH;
-const SWITCH_TOGGLE_WIDTH = RECT_WIDTH;
-const SWITCH_OFF_COLOR = "gainsboro";
-const SWITCH_ON_COLOR = "MediumAquamarine";
+const SWITCH_GROUP_CLASS_NAME = "all-toggles";
+
+const TOGGLES_GAP = 20;
+const TOGGLE_HEIGHT = RECT_WIDTH;
+const TOGGLE_WIDTH = RECT_WIDTH;
+const TOGGLE_OFF_COLOR = "gainsboro";
+const TOGGLE_ON_COLOR = "MediumAquamarine";
 
 const LED_TOGGLES_Y = SWITCH_TOGGLES_Y;
 
@@ -153,7 +155,7 @@ namespace pxsim.visuals {
     }
 
     // Add toggles add/remove switches
-    group.append(addSwitchToggles());
+    group.append(addSwitchToggles(SWITCH_TOGGLES_Y, SWITCH_GROUP_CLASS_NAME, "Add Switch"));
 
     return root.firstElementChild as SVGAElement;
   }
@@ -262,46 +264,46 @@ namespace pxsim.visuals {
     return group;
   }
 
-  function addSwitchToggles() {
+  function addSwitchToggles(yOffset: number, groupClassName: string, label: string) {
     const group = createSvgElement("g");
-    group.classList.add("all-toggles");
+    group.classList.add(groupClassName);
 
     const labelText = createSvgElement("text");
     labelText.setAttribute("x", "0");
-    labelText.setAttribute("y", `${SWITCH_TOGGLES_Y}`);
+    labelText.setAttribute("y", `${yOffset}`);
     labelText.setAttribute("textAnchor", "left");
-    labelText.innerHTML = "Add Switch";
+    labelText.innerHTML = label;
     group.append(labelText);
 
     for (let i = 0; i < NUMBER_OF_GPIO_PINS; i++) {
-      const toggle = createSwitchToggle(i);
+      const toggle = createSwitchToggle(i, yOffset);
       group.append(toggle);
     }
 
     return group;
   }
 
-  function createSwitchToggle(pinIndex: number) {
+  function createSwitchToggle(pinIndex: number, overallYOffset: number) {
     const group = createSvgElement("g");
     group.id = `switch-toggle${pinIndex}`;
     group.classList.add("toggle-group");
     const pinRect = createSvgElement("rect");
     pinRect.classList.add("toggle");
     pinRect.setAttribute("data-pin-index", `${pinIndex}`);
-    pinRect.setAttribute("x", `${RECT_X_DISTANCE * pinIndex}`);
-    pinRect.setAttribute("y", `${SWITCH_TOGGLES_Y + SWITCH_TOGGLES_GAP}`);
-    pinRect.setAttribute("height", `${SWITCH_TOGGLE_HEIGHT}`);
-    pinRect.setAttribute("width", `${SWITCH_TOGGLE_WIDTH}`);
-    pinRect.setAttribute("fill", SWITCH_OFF_COLOR);
+    pinRect.setAttribute("x", `${(TOGGLE_WIDTH + TOGGLES_GAP) * pinIndex}`);
+    pinRect.setAttribute("y", `${overallYOffset + TOGGLES_GAP}`);
+    pinRect.setAttribute("height", `${TOGGLE_HEIGHT}`);
+    pinRect.setAttribute("width", `${TOGGLE_WIDTH}`);
+    pinRect.setAttribute("fill", TOGGLE_OFF_COLOR);
 
     const labelText = createSvgElement("text");
     labelText.setAttribute(
       "x",
-      `${RECT_X_DISTANCE * pinIndex + SWITCH_TOGGLE_WIDTH / 2 - 3}`
+      `${RECT_X_DISTANCE * pinIndex + TOGGLE_WIDTH / 2 - 3}`
     );
     labelText.setAttribute(
       "y",
-      `${SWITCH_TOGGLES_Y + SWITCH_TOGGLES_GAP + SWITCH_TOGGLE_HEIGHT / 2 + 4}`
+      `${SWITCH_TOGGLES_Y + TOGGLES_GAP + TOGGLE_HEIGHT / 2 + 4}`
     );
     labelText.setAttribute("textAnchor", "middle");
     labelText.innerHTML = `${pinIndex}`;
@@ -397,7 +399,7 @@ namespace pxsim.visuals {
       }
 
       const switchToggles = this.element.querySelectorAll(
-        ".all-toggles .toggle-group"
+        `.${SWITCH_GROUP_CLASS_NAME} .toggle-group`
       );
       for (const toggle of switchToggles) {
         toggle.addEventListener("click", () => {
@@ -440,7 +442,7 @@ namespace pxsim.visuals {
       const toggleBody = this.element.querySelector(
         `#switch-toggle${pinIndex} .toggle`
       );
-      return toggleBody.getAttribute("fill") === SWITCH_ON_COLOR;
+      return toggleBody.getAttribute("fill") === TOGGLE_ON_COLOR;
     }
 
     private setSwitchLineShowing(pinIndex: number, isShowing: boolean) {
@@ -449,10 +451,10 @@ namespace pxsim.visuals {
       );
       const switchWireEl = this.element.querySelector(`#switch${pinIndex}`);
       if (isShowing) {
-        toggleBody.setAttribute("fill", SWITCH_ON_COLOR);
+        toggleBody.setAttribute("fill", TOGGLE_ON_COLOR);
         switchWireEl.classList.add("chibi-visible");
       } else {
-        toggleBody.setAttribute("fill", SWITCH_OFF_COLOR);
+        toggleBody.setAttribute("fill", TOGGLE_OFF_COLOR);
         switchWireEl.classList.remove("chibi-visible");
       }
     }

--- a/sim/visuals/chibiclip.ts
+++ b/sim/visuals/chibiclip.ts
@@ -54,6 +54,18 @@ const TOGGLE_HEIGHT = RECT_WIDTH;
 const TOGGLE_WIDTH = RECT_WIDTH;
 
 const LED_TOGGLES_Y = SWITCH_TOGGLES_Y;
+const LIGHT_WIDTH = 36;
+// 
+//   |\
+// a | \ c
+//   |__\
+//     b
+// a^2 + b^2 = c^2
+// a = Math.sqrt(c^2 - b^2)
+// c = LIGHT_WIDTH
+// b = LIGHT_WIDTH / 2
+const LIGHT_HEIGHT = Math.sqrt(Math.pow(LIGHT_WIDTH, 2) - Math.pow(LIGHT_WIDTH / 2, 2));
+const LIGHT_Y = CLIP_HEIGHT + SWITCH_OFF_INITIAL_WIRE_HEIGHT;
 
 const POWER_PIN_INDEX = TOTAL_NUMBER_OF_PINS - 2;
 const GROUND_PIN_INDEX = TOTAL_NUMBER_OF_PINS - 1;
@@ -198,6 +210,26 @@ namespace pxsim.visuals {
     return labelText;
   }
 
+  function createLightTriangle(
+    pinIndex: number,
+    className: string,
+  ) {
+    const polygon = createSvgElement("polygon");
+    polygon.classList.add(className);
+    const xCenterPoint = RECT_X_OFFSET + RECT_X_DISTANCE * pinIndex + RECT_WIDTH / 2;
+
+    const x1 = xCenterPoint - LIGHT_WIDTH / 2;
+    const x2 = x1 + LIGHT_WIDTH;
+    const x3 = xCenterPoint;
+    const y1 = LIGHT_Y;
+    const y2 = LIGHT_Y;
+    const y3 = LIGHT_Y + LIGHT_HEIGHT;
+
+    const points = `${x1},${y1} ${x2},${y2} ${x3},${y3}`;
+    polygon.setAttribute("points", points);
+    return polygon;
+  }
+
   function createLightCircle(
     pinIndex: number,
     className: string,
@@ -222,7 +254,7 @@ namespace pxsim.visuals {
 
     const widthOffset = (RECT_WIDTH - WIRE_WIDTH) / 2;
     const startingX = widthOffset + RECT_X_OFFSET + RECT_X_DISTANCE * i;
-    const bottomOfClipY = RECT_Y + RECT_HEIGHT;
+    const bottomOfClipY = CLIP_HEIGHT;
 
     const initialRect = createSvgElement("rect");
     initialRect.setAttribute("x", `${startingX}`);
@@ -318,6 +350,18 @@ namespace pxsim.visuals {
     const points = `${x1},${y1} ${x2},${y2} ${x3},${y3} ${x4},${y4} ${x5},${y5} ${x6},${y6} ${x7},${y7} ${x8},${y8}`;
     polygon.setAttribute("points", points);
     group.append(polygon);
+
+    const lightGroup = createSvgElement("g");
+    lightGroup.id = getLightIdName(i, LIGHT_GROUP_CLASS_NAME);
+
+    const lightGraphicBottom = createLightTriangle(i, 'triangle-base');
+    lightGroup.append(lightGraphicBottom);
+
+    const lightGraphicTop = createLightTriangle(i, 'triangle-light');
+    lightGroup.append(lightGraphicTop);
+
+    group.append(lightGroup);
+
     return group;
   }
 
@@ -346,6 +390,10 @@ namespace pxsim.visuals {
 
   function getWireIdName(pinIndex: number, groupClassName: string) {
     return `${groupClassName}-wire-${pinIndex}`;
+  }
+
+  function getLightIdName(pinIndex: number, groupClassName: string) {
+    return `${groupClassName}-light-${pinIndex}`;
   }
 
   function createToggle(
@@ -439,6 +487,14 @@ namespace pxsim.visuals {
             .wire .clickableGap.on,
             .wire rect, .wire polygon {
               fill: Silver;
+            }
+            
+            .wire polygon.triangle-base {
+              fill: gray;
+            }
+            
+            .wire polygon.triangle-light {
+              fill: white;
             }
 
             .wire.chibi-visible {

--- a/sim/visuals/chibiclip.ts
+++ b/sim/visuals/chibiclip.ts
@@ -261,6 +261,7 @@ namespace pxsim.visuals {
     initialRect.setAttribute("y", `${bottomOfClipY}`);
     initialRect.setAttribute("height", `${SWITCH_OFF_INITIAL_WIRE_HEIGHT}`);
     initialRect.setAttribute("width", `${WIRE_WIDTH}`);
+    initialRect.classList.add("wire");
     group.append(initialRect);
 
     const gapButton = createSvgElement("rect");
@@ -271,12 +272,12 @@ namespace pxsim.visuals {
     );
     gapButton.setAttribute("height", `${SWITCH_GAP}`);
     gapButton.setAttribute("width", `${WIRE_WIDTH}`);
-    gapButton.classList.add("clickableGap");
-    gapButton.classList.add("off");
+    gapButton.classList.add("clickableGap", "off");
     gapButton.setAttribute("data-pin-index", `${i}`);
     group.append(gapButton);
 
     const polygon = createSvgElement("polygon");
+    polygon.classList.add("wire");
 
     const x1 = startingX;
     const y1 = bottomOfClipY + SWITCH_OFF_INITIAL_WIRE_HEIGHT + SWITCH_GAP;
@@ -319,6 +320,7 @@ namespace pxsim.visuals {
     const bottomOfClipY = RECT_Y + RECT_HEIGHT;
 
     const polygon = createSvgElement("polygon");
+    polygon.classList.add("wire")
 
     const x1 = startingX;
     // const y1 = bottomOfClipY + wireHeight + SWITCH_GAP;
@@ -487,7 +489,7 @@ namespace pxsim.visuals {
             }
 
             .circuit .clickableGap.on,
-            .circuit rect, .circuit polygon {
+            .circuit .wire {
               fill: Silver;
             }
             

--- a/sim/visuals/chibiclip.ts
+++ b/sim/visuals/chibiclip.ts
@@ -318,7 +318,7 @@ namespace pxsim.visuals {
     return group;
   }
 
-  function createLightFromPinToGround(i: number, hasJump = true) {
+  function createLightFromPinToGround(i: number, hasJump: boolean) {
     const group = createSvgElement("g");
     group.setAttribute("id", `${getWireIdName(i, LIGHT_GROUP_CLASS_NAME)}`);
     group.classList.add("circuit");
@@ -648,8 +648,19 @@ namespace pxsim.visuals {
       }
     }
 
+    private lightWireHasJump(pinIndex: number) {
+      // If a pin before it has a switch
+      for (let i = 0; i < NUMBER_OF_GPIO_PINS; i++) {
+        const value = this.getToggleValue(i, SWITCH_GROUP_CLASS_NAME);
+        if (value === ToggleValue.On) {
+          return true;
+        }
+      }
+      return false;
+    }
+
     private turnOnLight(pinIndex: number) {
-      const wireEl = createLightFromPinToGround(pinIndex);
+      const wireEl = createLightFromPinToGround(pinIndex, this.lightWireHasJump(pinIndex));
       this.part.el.append(wireEl);
       this.setToggleValue(pinIndex, LIGHT_GROUP_CLASS_NAME, ToggleValue.On);
     }

--- a/sim/visuals/chibiclip.ts
+++ b/sim/visuals/chibiclip.ts
@@ -358,6 +358,7 @@ namespace pxsim.visuals {
     lightGroup.append(lightGraphicBottom);
 
     const lightGraphicTop = createLightTriangle(i, 'triangle-light');
+    lightGraphicTop.classList.add("off");
     lightGroup.append(lightGraphicTop);
 
     group.append(lightGroup);
@@ -495,6 +496,14 @@ namespace pxsim.visuals {
             
             .wire polygon.triangle-light {
               fill: white;
+              stroke: rgb(235, 235, 235);
+              stroke-width: 3;
+              stroke-miterlimit: 10;
+              filter: url("#ledGlow");
+            }
+            
+            .wire polygon.triangle-light.off {
+              display: none;
             }
 
             .wire.chibi-visible {

--- a/sim/visuals/chibiclip.ts
+++ b/sim/visuals/chibiclip.ts
@@ -8,10 +8,10 @@ const CLIP_WIDTH = 420;
 const CLIP_HEIGHT = 120;
 
 const NUMBER_OF_GPIO_PINS = 6;
-const TOTAL_NUMBER_OF_PINS = NUMBER_OF_GPIO_PINS + 1; // GPIO + ground
+const TOTAL_NUMBER_OF_PINS = NUMBER_OF_GPIO_PINS + 2; // GPIO + power + ground
 
 const ITEM_WIDTH = 30;
-const GAP = 25;
+const GAP = 20;
 const SPACING = ITEM_WIDTH + GAP;
 const ALL_ITEMS_WIDTH =
   TOTAL_NUMBER_OF_PINS * ITEM_WIDTH + GAP * (TOTAL_NUMBER_OF_PINS - 1);
@@ -129,7 +129,14 @@ namespace pxsim.visuals {
       pinGroup.append(labelText);
     }
 
-    // Add ground pin
+    // Add voltage pin
+    const powerPin = createPinRectangle(
+      TOTAL_NUMBER_OF_PINS - 2,
+      "power",
+      RECT_DEFAULT_FILL
+    );
+    group.append(powerPin);
+
     const groundPin = createPinRectangle(
       TOTAL_NUMBER_OF_PINS - 1,
       "ground",

--- a/sim/visuals/chibiclip.ts
+++ b/sim/visuals/chibiclip.ts
@@ -37,7 +37,7 @@ const TEXT_Y = RECT_Y + RECT_Y / 2;
 const TEXT_X_OFFSET = X_OFFSET;
 const TEXT_X_DISTANCE = SPACING;
 
-const WIRE_WIDTH = 10;
+const WIRE_WIDTH = 12;
 const SWITCH_GAP = 30;
 
 const SWITCH_WIRE_HEIGHT = 90;
@@ -47,7 +47,7 @@ const SWITCH_OFF_INITIAL_WIRE_HEIGHT = 30;
 
 const LIGHT_TOGGLES_Y = SWITCH_TOGGLES_Y + 100;
 const LIGHT_GROUP_CLASS_NAME = "all-light-toggles";
-const LIGHT_WIRE_HEIGHT = 120;
+const LIGHT_WIRE_HEIGHT = 140;
 
 const TOGGLES_GAP = 20;
 const TOGGLE_HEIGHT = RECT_WIDTH;
@@ -416,14 +416,11 @@ namespace pxsim.visuals {
 
             .wire .clickableGap.off {
               fill: transparent;
-              stroke: none;
             }
 
             .wire .clickableGap.on,
             .wire rect, .wire polygon {
               fill: gainsboro;
-              stroke: gray;
-              stroke-width: 1px;
             }
 
             .wire.chibi-visible {

--- a/sim/visuals/chibiclip.ts
+++ b/sim/visuals/chibiclip.ts
@@ -7,12 +7,14 @@ const CLIP_Y = 220;
 const CLIP_WIDTH = 420;
 const CLIP_HEIGHT = 120;
 
-const NUM_PINS = 6;
+const NUMBER_OF_GPIO_PINS = 6;
+const TOTAL_NUMBER_OF_PINS = NUMBER_OF_GPIO_PINS + 1; // GPIO + ground
 
 const ITEM_WIDTH = 30;
-const GAP = 35;
+const GAP = 25;
 const SPACING = ITEM_WIDTH + GAP;
-const ALL_ITEMS_WIDTH = NUM_PINS * ITEM_WIDTH + GAP * (NUM_PINS - 1);
+const ALL_ITEMS_WIDTH =
+  TOTAL_NUMBER_OF_PINS * ITEM_WIDTH + GAP * (TOTAL_NUMBER_OF_PINS - 1);
 const X_OFFSET = (CLIP_WIDTH - ALL_ITEMS_WIDTH) / 2;
 
 const RECT_WIDTH = ITEM_WIDTH;
@@ -20,13 +22,14 @@ const RECT_HEIGHT = 50;
 const RECT_Y = CLIP_HEIGHT - RECT_HEIGHT;
 const RECT_X_OFFSET = X_OFFSET;
 const RECT_X_DISTANCE = SPACING;
-const RECT_DEFAULT_FILL = 'hsl(185.35, 66%, 54%)'; //chibiblue
+const RECT_DEFAULT_FILL = "hsl(185.35,66%,54%)"; //chibiblue
 
 const CIRCLE_RECT_GAP = 10;
 
 const CIRCLE_RADIUS = ITEM_WIDTH / 2;
-const CIRCLE_DEFAULT_FILL = 'gray';
-const CIRCLE_Y = CLIP_HEIGHT - RECT_HEIGHT - CIRCLE_RADIUS * 2 - CIRCLE_RECT_GAP;
+const CIRCLE_DEFAULT_FILL = "gray";
+const CIRCLE_Y =
+  CLIP_HEIGHT - RECT_HEIGHT - CIRCLE_RADIUS * 2 - CIRCLE_RECT_GAP;
 const CIRCLE_X_OFFSET = X_OFFSET + CIRCLE_RADIUS;
 const CIRCLE_X_DISTANCE = SPACING;
 
@@ -34,6 +37,20 @@ const TEXT_Y = 140;
 const TEXT_X_OFFSET = X_OFFSET;
 const TEXT_X_DISTANCE = SPACING;
 
+const WIRE_WIDTH = 20;
+const WIRE_DISTANCE = 150;
+const SWITCH_DISTANCE = 60;
+const SWITCH_GAP = 40;
+const WIRE_COLOR = "gray";
+const GAP_OFF_COLOR = "transparent";
+const GAP_ON_COLOR = WIRE_COLOR;
+
+const SWITCH_TOGGLES_Y = CLIP_HEIGHT + WIRE_DISTANCE + WIRE_WIDTH + 50;
+const SWITCH_TOGGLES_GAP = 20;
+const SWITCH_TOGGLE_HEIGHT = RECT_HEIGHT;
+const SWITCH_TOGGLE_WIDTH = RECT_WIDTH;
+const SWITCH_OFF_COLOR = "gainsboro";
+const SWITCH_ON_COLOR = "green";
 
 namespace pxsim.visuals {
   function createSvgElement(tagName: string) {
@@ -44,7 +61,7 @@ namespace pxsim.visuals {
     const defsElement = createSvgElement("defs");
     const filterElement = createSvgElement("filter");
     defsElement.append(filterElement);
-    filterElement.setAttribute('id', 'ledGlow');
+    filterElement.setAttribute("id", "ledGlow");
     const feGaussianBlurElement = createSvgElement("feGaussianBlur");
     feGaussianBlurElement.setAttribute("stdDeviation", "4");
     feGaussianBlurElement.setAttribute("result", "coloredBlur");
@@ -52,9 +69,9 @@ namespace pxsim.visuals {
     const feMergeElement = createSvgElement("feMerge");
     filterElement.append(feMergeElement);
     const feMergeNodeElement1 = createSvgElement("feMergeNode");
-    feMergeNodeElement1.setAttribute("in", "coloredBlur")
+    feMergeNodeElement1.setAttribute("in", "coloredBlur");
     const feMergeNodeElement2 = createSvgElement("feMergeNode");
-    feMergeNodeElement2.setAttribute("in", "coloredBlur")
+    feMergeNodeElement2.setAttribute("in", "coloredBlur");
     const feMergeNodeElement3 = createSvgElement("feMergeNode");
     feMergeNodeElement3.setAttribute("in", "SourceGraphic");
     feMergeElement.append(feMergeNodeElement1);
@@ -64,69 +81,219 @@ namespace pxsim.visuals {
   }
 
   function generateSvg(): SVGAElement {
-    const root = svg.parseString(`<svg xmlns="http://www.w3.org/2000/svg" width="${CLIP_WIDTH}" height="${CLIP_HEIGHT}"></svg>`);
-    const group = createSvgElement('g');
+    const root = svg.parseString(
+      `<svg xmlns="http://www.w3.org/2000/svg" width="${CLIP_WIDTH}" height="${CLIP_HEIGHT}"></svg>`
+    );
+    const group = createSvgElement("g");
     const defEl = ledGlow();
     group.append(defEl);
     root.append(group);
 
     // Add clip element
-    const clipElement = createSvgElement('rect');
-    clipElement.setAttribute('width', `${CLIP_WIDTH}`);
-    clipElement.setAttribute('height', `${CLIP_HEIGHT}`);
-    clipElement.setAttribute('fill', 'hsl(44.772, 100%, 61%)');//chibiyellow
+    const clipElement = createSvgElement("rect");
+    clipElement.setAttribute("width", `${CLIP_WIDTH}`);
+    clipElement.setAttribute("height", `${CLIP_HEIGHT}`);
+    clipElement.setAttribute("fill", "hsl(44.772, 100%, 61%)"); //chibiyellow
     group.append(clipElement);
 
-    // Add pins
-    for (let i = 0; i < NUM_PINS; i++) {
-      const pinGroup = createSvgElement('g');
-      pinGroup.setAttribute('id', `pin${i}`);
+    // Add gpio pins
+    for (let i = 0; i < NUMBER_OF_GPIO_PINS; i++) {
+      const pinGroup = createSvgElement("g");
+      pinGroup.setAttribute("id", `pin${i}`);
       group.append(pinGroup);
 
-      const defaultCircle = createSvgElement('circle');
-      defaultCircle.classList.add('default');
-      defaultCircle.setAttribute('cx', `${CIRCLE_X_OFFSET + CIRCLE_X_DISTANCE * i}`);
-      defaultCircle.setAttribute('cy', `${CIRCLE_Y}`);
-      defaultCircle.setAttribute('r', `${CIRCLE_RADIUS}`);
-      defaultCircle.setAttribute('fill', CIRCLE_DEFAULT_FILL);
+      const defaultCircle = createLightCircle(
+        i,
+        "default",
+        CIRCLE_DEFAULT_FILL
+      );
       pinGroup.append(defaultCircle);
 
-      const levelCircle = createSvgElement('circle');
-      levelCircle.classList.add('level');
-      levelCircle.setAttribute('cx', `${CIRCLE_X_OFFSET + CIRCLE_X_DISTANCE * i}`);
-      levelCircle.setAttribute('cy', `${CIRCLE_Y}`);
-      levelCircle.setAttribute('r', `${CIRCLE_RADIUS}`);
-      levelCircle.setAttribute('fill', 'transparent');
+      const levelCircle = createLightCircle(i, "level", "transparent");
       pinGroup.append(levelCircle);
 
-      const defaultRect = createSvgElement('rect');
-      defaultRect.classList.add('default');
-      defaultRect.setAttribute('x', `${RECT_X_OFFSET + RECT_X_DISTANCE * i}`);
-      defaultRect.setAttribute('y', `${RECT_Y}`);
-      defaultRect.setAttribute('height', `${RECT_HEIGHT}`);
-      defaultRect.setAttribute('width', `${RECT_WIDTH}`);
-      defaultRect.setAttribute('fill', RECT_DEFAULT_FILL);
+      const defaultRect = createPinRectangle(i, "default", RECT_DEFAULT_FILL);
       pinGroup.append(defaultRect);
 
-      const levelRect = createSvgElement('rect');
-      levelRect.classList.add('level');
-      levelRect.setAttribute('x', `${RECT_X_OFFSET + RECT_X_DISTANCE * i}`);
-      levelRect.setAttribute('y', `${RECT_Y}`);
-      levelRect.setAttribute('height', `${RECT_HEIGHT}`);
-      levelRect.setAttribute('width', `${RECT_WIDTH}`);
-      levelRect.setAttribute('fill', 'transparent');
+      const levelRect = createPinRectangle(i, "level", "transparent");
       pinGroup.append(levelRect);
 
-      const labelText = createSvgElement('text');
-      labelText.classList.add('label');
-      labelText.setAttribute('x', `${TEXT_X_OFFSET + TEXT_X_DISTANCE * i}`);
-      labelText.setAttribute('y', `${TEXT_Y}`);
-      labelText.setAttribute('textAnchor', 'middle');
+      const labelText = createSvgElement("text");
+      labelText.classList.add("label");
+      labelText.setAttribute("x", `${TEXT_X_OFFSET + TEXT_X_DISTANCE * i}`);
+      labelText.setAttribute("y", `${TEXT_Y}`);
+      labelText.setAttribute("textAnchor", "middle");
       // labelText.innerHTML = 'OFF';
       pinGroup.append(labelText);
     }
 
+    // Add ground pin
+    const groundPin = createPinRectangle(
+      TOTAL_NUMBER_OF_PINS - 1,
+      "ground",
+      RECT_DEFAULT_FILL
+    );
+    group.append(groundPin);
+
+    // Add switches (starts invisible)
+    for (let i = 0; i < NUMBER_OF_GPIO_PINS; i++) {
+      const switchLine = createSwitchFromPinToGround(i);
+      group.append(switchLine);
+    }
+
+    // Add toggles add/remove switches
+    group.append(addSwitchToggles());
+
     return root.firstElementChild as SVGAElement;
+  }
+
+  function createPinRectangle(
+    pinIndex: number,
+    className: string,
+    fillColor: string
+  ) {
+    const pinRect = createSvgElement("rect");
+    pinRect.classList.add(className);
+    pinRect.setAttribute("x", `${RECT_X_OFFSET + RECT_X_DISTANCE * pinIndex}`);
+    pinRect.setAttribute("y", `${RECT_Y}`);
+    pinRect.setAttribute("height", `${RECT_HEIGHT}`);
+    pinRect.setAttribute("width", `${RECT_WIDTH}`);
+    pinRect.setAttribute("fill", fillColor);
+    return pinRect;
+  }
+
+  function createLightCircle(
+    pinIndex: number,
+    className: string,
+    fillColor: string
+  ) {
+    const levelCircle = createSvgElement("circle");
+    levelCircle.classList.add(className);
+    levelCircle.setAttribute(
+      "cx",
+      `${CIRCLE_X_OFFSET + CIRCLE_X_DISTANCE * pinIndex}`
+    );
+    levelCircle.setAttribute("cy", `${CIRCLE_Y}`);
+    levelCircle.setAttribute("r", `${CIRCLE_RADIUS}`);
+    levelCircle.setAttribute("fill", fillColor);
+    return levelCircle;
+  }
+
+  function createSwitchFromPinToGround(i: number) {
+    const group = createSvgElement("g");
+    group.setAttribute("id", `switch${i}`);
+    group.classList.add("wire");
+
+    const widthOffset = (RECT_WIDTH - WIRE_WIDTH) / 2;
+    const startingX = widthOffset + RECT_X_OFFSET + RECT_X_DISTANCE * i;
+    const bottomOfClipY = RECT_Y + RECT_HEIGHT;
+
+    const initialRect = createSvgElement("rect");
+    initialRect.setAttribute("x", `${startingX}`);
+    initialRect.setAttribute("y", `${bottomOfClipY}`);
+    initialRect.setAttribute("height", `${SWITCH_DISTANCE}`);
+    initialRect.setAttribute("width", `${WIRE_WIDTH}`);
+    initialRect.setAttribute("fill", "gray");
+    group.append(initialRect);
+
+    const gapButton = createSvgElement("rect");
+    gapButton.setAttribute("x", `${startingX}`);
+    gapButton.setAttribute("y", `${bottomOfClipY + SWITCH_DISTANCE}`);
+    gapButton.setAttribute("height", `${SWITCH_GAP}`);
+    gapButton.setAttribute("width", `${WIRE_WIDTH}`);
+    gapButton.setAttribute("fill", GAP_OFF_COLOR);
+    gapButton.classList.add("clickableGap");
+    gapButton.setAttribute("data-pin-index", `${i}`);
+    group.append(gapButton);
+
+    const polygon = createSvgElement("polygon");
+
+    const x1 = startingX;
+    const y1 = bottomOfClipY + SWITCH_DISTANCE + SWITCH_GAP;
+
+    const x2 = x1 + WIRE_WIDTH;
+    const y2 = y1;
+
+    const x3 = x2;
+    const y3 = y2 + (WIRE_DISTANCE - SWITCH_DISTANCE - SWITCH_GAP);
+
+    const groundPinStartingX =
+      RECT_X_OFFSET + RECT_X_DISTANCE * (TOTAL_NUMBER_OF_PINS - 1);
+    const x4 = groundPinStartingX + widthOffset;
+    const y4 = y3;
+
+    const x5 = x4;
+    const y5 = bottomOfClipY;
+
+    const x6 = x5 + WIRE_WIDTH;
+    const y6 = y5;
+
+    const x7 = x6;
+    const y7 = y3 + WIRE_WIDTH;
+
+    const x8 = x1;
+    const y8 = y7;
+
+    // 1- 30,120
+    // 2- 60,120
+    // 3- 60,220
+    // 4- 360,220
+    // 5- 360,120
+    // 6- 390,120 390,250 30,250
+    const points = `${x1},${y1} ${x2},${y2} ${x3},${y3} ${x4},${y4} ${x5},${y5} ${x6},${y6} ${x7},${y7} ${x8},${y8}`;
+    polygon.setAttribute("points", points);
+    polygon.setAttribute("fill", WIRE_COLOR);
+    group.append(polygon);
+    return group;
+  }
+
+  function addSwitchToggles() {
+    const group = createSvgElement("g");
+    group.classList.add("all-toggles");
+
+    const labelText = createSvgElement("text");
+    labelText.setAttribute("x", "0");
+    labelText.setAttribute("y", `${SWITCH_TOGGLES_Y}`);
+    labelText.setAttribute("textAnchor", "left");
+    labelText.innerHTML = "Add Switch";
+    group.append(labelText);
+
+    for (let i = 0; i < NUMBER_OF_GPIO_PINS; i++) {
+      const toggle = createSwitchToggle(i);
+      group.append(toggle);
+    }
+
+    return group;
+  }
+
+  function createSwitchToggle(pinIndex: number) {
+    const group = createSvgElement("g");
+    group.id = `switch-toggle${pinIndex}`;
+    group.classList.add("toggle-group");
+    const pinRect = createSvgElement("rect");
+    pinRect.classList.add("toggle");
+    pinRect.setAttribute("data-pin-index", `${pinIndex}`);
+    pinRect.setAttribute("x", `${RECT_X_DISTANCE * pinIndex}`);
+    pinRect.setAttribute("y", `${SWITCH_TOGGLES_Y + SWITCH_TOGGLES_GAP}`);
+    pinRect.setAttribute("height", `${SWITCH_TOGGLE_HEIGHT}`);
+    pinRect.setAttribute("width", `${SWITCH_TOGGLE_WIDTH}`);
+    pinRect.setAttribute("fill", SWITCH_OFF_COLOR);
+
+    const labelText = createSvgElement("text");
+    labelText.setAttribute(
+      "x",
+      `${RECT_X_DISTANCE * pinIndex + SWITCH_TOGGLE_WIDTH / 2 - 3}`
+    );
+    labelText.setAttribute(
+      "y",
+      `${SWITCH_TOGGLES_Y + SWITCH_TOGGLES_GAP + RECT_HEIGHT / 2 + 4}`
+    );
+    labelText.setAttribute("textAnchor", "middle");
+    labelText.innerHTML = `${pinIndex}`;
+    group.append(pinRect);
+    group.append(labelText);
+
+    return group;
   }
 
   // For the instructions parts list
@@ -143,6 +310,14 @@ namespace pxsim.visuals {
   export class ChibiClipView implements IBoardPart<EdgeConnectorState> {
     public style: string = `
             .sim-chibichip {
+            }
+
+            .wire {
+              display: none;
+            }
+
+            .wire.chibi-visible {
+              display: block;
             }
         `;
     public element: SVGElement;
@@ -172,6 +347,85 @@ namespace pxsim.visuals {
       this.part = part;
       this.stripGroup.appendChild(part.el);
       this.overElement = null;
+
+      // Add switch event listeners
+      const clickableGaps = this.element.querySelectorAll(
+        ".wire .clickableGap"
+      );
+      for (const gap of clickableGaps) {
+        gap.addEventListener("click", () => {
+          const pinIndex = parseInt(gap.getAttribute("data-pin-index"));
+          const pin = this.state.pins[pinIndex];
+          if (this.isGapClicked(pinIndex)) {
+            this.setGapClicked(pinIndex, false);
+            pin.digitalWritePin(0);
+          } else {
+            this.setGapClicked(pinIndex, true);
+            pin.digitalWritePin(1);
+          }
+        });
+      }
+
+      const switchToggles = this.element.querySelectorAll(
+        ".all-toggles .toggle-group"
+      );
+      for (const toggle of switchToggles) {
+        toggle.addEventListener("click", () => {
+          console.log('clicked toggle');
+          const toggleBody = toggle.querySelector(`.toggle`);
+          const pinIndex = parseInt(toggleBody.getAttribute("data-pin-index"));
+          const pin = this.state.pins[pinIndex];
+          if (this.isSwitchLineShowing(pinIndex)) {
+            this.setSwitchLineShowing(pinIndex, false);
+            if (this.isGapClicked(pinIndex)) {
+              this.setGapClicked(pinIndex, false);
+              pin.digitalWritePin(0);
+            }
+          } else {
+            this.setSwitchLineShowing(pinIndex, true);
+          }
+        });
+      }
+    }
+
+    private isGapClicked(pinIndex: number) {
+      const gap = this.element.querySelector(
+        `#switch${pinIndex} .clickableGap`
+      );
+      return gap.getAttribute("fill") === GAP_ON_COLOR;
+    }
+
+    private setGapClicked(pinIndex: number, isClicked: boolean) {
+      const gap = this.element.querySelector(
+        `#switch${pinIndex} .clickableGap`
+      );
+      if (isClicked) {
+        gap.setAttribute("fill", GAP_ON_COLOR);
+        
+      } else {
+        gap.setAttribute("fill", GAP_OFF_COLOR);
+      }
+    }
+
+    private isSwitchLineShowing(pinIndex: number) {
+      const toggleBody = this.element.querySelector(
+        `#switch-toggle${pinIndex} .toggle`
+      );
+      return toggleBody.getAttribute("fill") === SWITCH_ON_COLOR;
+    }
+
+    private setSwitchLineShowing(pinIndex: number, isShowing: boolean) {
+      const toggleBody = this.element.querySelector(
+        `#switch-toggle${pinIndex} .toggle`
+      );
+      const switchWireEl = this.element.querySelector(`#switch${pinIndex}`);
+      if (isShowing) {
+        toggleBody.setAttribute("fill", SWITCH_ON_COLOR);
+        switchWireEl.classList.add("chibi-visible");
+      } else {
+        toggleBody.setAttribute("fill", SWITCH_OFF_COLOR);
+        switchWireEl.classList.remove("chibi-visible");
+      }
     }
 
     public moveToCoord(xy: Coord): void {
@@ -183,11 +437,13 @@ namespace pxsim.visuals {
 
     private updateClipLoc() {
       // Hardcode the value for now:
-      svg.hydrate(this.part.el, { transform: `translate(${CLIP_X} ${CLIP_Y})` });
+      svg.hydrate(this.part.el, {
+        transform: `translate(${CLIP_X} ${CLIP_Y})`,
+      });
     }
 
     public updateState(): void {
-      for (let i = 0; i < 10; i++) {
+      for (let i = 0; i < TOTAL_NUMBER_OF_PINS; i++) {
         const pinLoaded = this.element.querySelector(`#pin${i}`);
         if (!pinLoaded) {
           return;
@@ -207,13 +463,17 @@ namespace pxsim.visuals {
 
     private resetPin(index: number) {
       const pinFillEl = this.element.querySelector(`#pin${index} rect.level`);
-      const pinLedFillEl = this.element.querySelector(`#pin${index} circle.level`);
+      const pinLedFillEl = this.element.querySelector(
+        `#pin${index} circle.level`
+      );
       const pinLabelEl = this.element.querySelector(`#pin${index} text.label`);
 
       pinLedFillEl.setAttribute("fill", "transparent");
       pinFillEl.setAttribute("height", `${RECT_HEIGHT}`);
       pinFillEl.setAttribute("y", `${RECT_Y}`);
       pinFillEl.setAttribute("fill", "transparent");
+      pinFillEl.removeAttribute("stroke");
+      pinFillEl.removeAttribute("filter");
       pinLabelEl.innerHTML = "";
     }
 
@@ -223,45 +483,49 @@ namespace pxsim.visuals {
       const isOn = pin.value > 0;
 
       const pinFillEl = this.element.querySelector(`#pin${index} rect.level`);
-      const pinLedFillEl = this.element.querySelector(`#pin${index} circle.level`);
-      const pinLabelEl = this.element.querySelector(`#pin${index} text.label`);
+      const pinLedFillEl = this.element.querySelector(
+        `#pin${index} circle.level`
+      );
 
       if (isOn) {
-        pinFillEl.setAttribute("fill", `hsl(112.5, 100%, 67%)`);//chibineongreen
-        pinLedFillEl.setAttribute("fill", 'rgb(255, 255, 255)');
-        pinLedFillEl.setAttribute("stroke", 'rgb(235, 235, 235)');
-        pinLedFillEl.setAttribute("stroke-width", '3');
-        pinLedFillEl.setAttribute("stroke-miterlimit", '10');
-        pinLedFillEl.setAttribute("filter", 'url("#ledGlow")');//chibiglow
+        pinFillEl.setAttribute("fill", `hsl(112.5, 100%, 67%)`); //chibineongreen
+        pinLedFillEl.setAttribute("fill", "rgb(255, 255, 255)");
+        pinLedFillEl.setAttribute("stroke", "rgb(235, 235, 235)");
+        pinLedFillEl.setAttribute("stroke-width", "3");
+        pinLedFillEl.setAttribute("stroke-miterlimit", "10");
+        pinLedFillEl.setAttribute("filter", 'url("#ledGlow")'); //chibiglow
       } else {
-        pinFillEl.setAttribute("fill", 'transparent');
+        pinFillEl.setAttribute("fill", "transparent");
         pinLedFillEl.setAttribute("fill", "transparent");
+        pinLedFillEl.removeAttribute("filter");
+        pinLedFillEl.removeAttribute("stroke");
       }
-      pinLabelEl.innerHTML = isOn ? "ON" : "OFF";
     }
 
     private setAnalogDisplay(index: number) {
       const pin = this.state.pins[index];
       U.assert((pin.mode & PinFlags.Analog) !== 0);
-      const percentFraction = (pin.value / ANALOG_PIN_MAX_VALUE);
+      const percentFraction = pin.value / ANALOG_PIN_MAX_VALUE;
       const percentageValue = Math.round(percentFraction * 100);
 
       const pinFillEl = this.element.querySelector(`#pin${index} rect.level`);
-      const pinLedFillEl = this.element.querySelector(`#pin${index} circle.level`);
+      const pinLedFillEl = this.element.querySelector(
+        `#pin${index} circle.level`
+      );
       const pinLabelEl = this.element.querySelector(`#pin${index} text.label`);
 
-      const fillHeight = RECT_HEIGHT * percentFraction
-      pinFillEl.setAttribute('fill', 'hsl(112.5, 100%, 67%)'); //chibineongreen
-      pinFillEl.setAttribute('height', `${fillHeight}`);
-      pinFillEl.setAttribute('y', `${RECT_Y + (RECT_HEIGHT - fillHeight)}`);
+      const fillHeight = RECT_HEIGHT * percentFraction;
+      pinFillEl.setAttribute("fill", "hsl(112.5, 100%, 67%)"); //chibineongreen
+      pinFillEl.setAttribute("height", `${fillHeight}`);
+      pinFillEl.setAttribute("y", `${RECT_Y + (RECT_HEIGHT - fillHeight)}`);
 
       pinLabelEl.innerHTML = `${percentageValue}%`;
       const alpha = percentFraction;
-      pinLedFillEl.setAttribute('fill', `rgba(255, 255, 255, ${alpha})`)
+      pinLedFillEl.setAttribute("fill", `rgba(255, 255, 255, ${alpha})`);
       pinLedFillEl.setAttribute("stroke", `rgb(235, 235, 235, ${alpha})`);
-      pinLedFillEl.setAttribute("stroke-width", '3');
-      pinLedFillEl.setAttribute("stroke-miterlimit", '10');
-      pinLedFillEl.setAttribute("filter", 'url("#ledGlow")');//chibiglow
+      pinLedFillEl.setAttribute("stroke-width", "3");
+      pinLedFillEl.setAttribute("stroke-miterlimit", "10");
+      pinLedFillEl.setAttribute("filter", 'url("#ledGlow")'); //chibiglow
     }
 
     public updateTheme(): void {}

--- a/sim/visuals/chibiclip.ts
+++ b/sim/visuals/chibiclip.ts
@@ -234,12 +234,6 @@ namespace pxsim.visuals {
     const x8 = x1;
     const y8 = y7;
 
-    // 1- 30,120
-    // 2- 60,120
-    // 3- 60,220
-    // 4- 360,220
-    // 5- 360,120
-    // 6- 390,120 390,250 30,250
     const points = `${x1},${y1} ${x2},${y2} ${x3},${y3} ${x4},${y4} ${x5},${y5} ${x6},${y6} ${x7},${y7} ${x8},${y8}`;
     polygon.setAttribute("points", points);
     polygon.setAttribute("fill", WIRE_COLOR);

--- a/sim/visuals/chibiclip.ts
+++ b/sim/visuals/chibiclip.ts
@@ -329,6 +329,14 @@ namespace pxsim.visuals {
               font-weight: bold;
             }
 
+            .toggle-group {
+              cursor: pointer;
+            }
+            
+            .toggle-group:hover .toggle {
+              fill: gray;
+            }
+
             svg text.pin-label {
               font-family: "Courier New";
             }

--- a/sim/visuals/chibiclip.ts
+++ b/sim/visuals/chibiclip.ts
@@ -443,7 +443,7 @@ namespace pxsim.visuals {
     }
 
     public updateState(): void {
-      for (let i = 0; i < TOTAL_NUMBER_OF_PINS; i++) {
+      for (let i = 0; i < NUMBER_OF_GPIO_PINS; i++) {
         const pinLoaded = this.element.querySelector(`#pin${i}`);
         if (!pinLoaded) {
           return;

--- a/sim/visuals/chibiclip.ts
+++ b/sim/visuals/chibiclip.ts
@@ -39,9 +39,6 @@ const TEXT_X_DISTANCE = SPACING;
 
 const WIRE_WIDTH = 10;
 const SWITCH_GAP = 30;
-const WIRE_COLOR = "gray";
-const GAP_OFF_COLOR = "transparent";
-const GAP_ON_COLOR = WIRE_COLOR;
 
 const SWITCH_WIRE_HEIGHT = 90;
 const SWITCH_TOGGLES_Y = CLIP_HEIGHT + SWITCH_WIRE_HEIGHT + WIRE_WIDTH + 100;
@@ -228,16 +225,18 @@ namespace pxsim.visuals {
     initialRect.setAttribute("y", `${bottomOfClipY}`);
     initialRect.setAttribute("height", `${SWITCH_OFF_INITIAL_WIRE_HEIGHT}`);
     initialRect.setAttribute("width", `${WIRE_WIDTH}`);
-    initialRect.setAttribute("fill", "gray");
     group.append(initialRect);
 
     const gapButton = createSvgElement("rect");
     gapButton.setAttribute("x", `${startingX}`);
-    gapButton.setAttribute("y", `${bottomOfClipY + SWITCH_OFF_INITIAL_WIRE_HEIGHT}`);
+    gapButton.setAttribute(
+      "y",
+      `${bottomOfClipY + SWITCH_OFF_INITIAL_WIRE_HEIGHT}`
+    );
     gapButton.setAttribute("height", `${SWITCH_GAP}`);
     gapButton.setAttribute("width", `${WIRE_WIDTH}`);
-    gapButton.setAttribute("fill", GAP_OFF_COLOR);
     gapButton.classList.add("clickableGap");
+    gapButton.classList.add("off");
     gapButton.setAttribute("data-pin-index", `${i}`);
     group.append(gapButton);
 
@@ -270,16 +269,8 @@ namespace pxsim.visuals {
 
     const points = `${x1},${y1} ${x2},${y2} ${x3},${y3} ${x4},${y4} ${x5},${y5} ${x6},${y6} ${x7},${y7} ${x8},${y8}`;
     polygon.setAttribute("points", points);
-    polygon.setAttribute("fill", WIRE_COLOR);
     group.append(polygon);
     return group;
-  }
-
-  function removeLightWire(i: number) {
-    const switchWireEl = this.element.querySelector(
-      `#${getWireIdName(i, LIGHT_GROUP_CLASS_NAME)}`
-    );
-    switchWireEl.remove();
   }
 
   function createLightFromPinToGround(i: number, wireHeight: number) {
@@ -303,7 +294,8 @@ namespace pxsim.visuals {
     const x3 = x2;
     const y3 = y2 + wireHeight;
 
-    const powerPinStartingX = RECT_X_OFFSET + RECT_X_DISTANCE * GROUND_PIN_INDEX;
+    const powerPinStartingX =
+      RECT_X_OFFSET + RECT_X_DISTANCE * GROUND_PIN_INDEX;
     const x4 = powerPinStartingX + widthOffset;
     const y4 = y3;
 
@@ -321,7 +313,6 @@ namespace pxsim.visuals {
 
     const points = `${x1},${y1} ${x2},${y2} ${x3},${y3} ${x4},${y4} ${x5},${y5} ${x6},${y6} ${x7},${y7} ${x8},${y8}`;
     polygon.setAttribute("points", points);
-    polygon.setAttribute("fill", WIRE_COLOR);
     group.append(polygon);
     return group;
   }
@@ -403,6 +394,7 @@ namespace pxsim.visuals {
             svg text {
               font-family: "Arial";
               font-weight: bold;
+              user-select: none;
             }
 
             .clickableGap,
@@ -420,6 +412,18 @@ namespace pxsim.visuals {
 
             .wire {
               display: none;
+            }
+
+            .wire .clickableGap.off {
+              fill: transparent;
+              stroke: none;
+            }
+
+            .wire .clickableGap.on,
+            .wire rect, .wire polygon {
+              fill: gainsboro;
+              stroke: gray;
+              stroke-width: 1px;
             }
 
             .wire.chibi-visible {
@@ -503,10 +507,13 @@ namespace pxsim.visuals {
           const toggleBody = toggle.querySelector(`.toggle`);
           const pinIndex = parseInt(toggleBody.getAttribute("data-pin-index"));
           if (this.isToggleOn(pinIndex, LIGHT_GROUP_CLASS_NAME)) {
-            removeLightWire(pinIndex);
             this.setToggleValue(pinIndex, LIGHT_GROUP_CLASS_NAME, false);
+            this.removeLightWire(pinIndex);
           } else {
-            const wireEl = createLightFromPinToGround(pinIndex, LIGHT_WIRE_HEIGHT);
+            const wireEl = createLightFromPinToGround(
+              pinIndex,
+              LIGHT_WIRE_HEIGHT
+            );
             this.part.el.append(wireEl);
             this.setToggleValue(pinIndex, LIGHT_GROUP_CLASS_NAME, true);
           }
@@ -514,11 +521,18 @@ namespace pxsim.visuals {
       }
     }
 
+    private removeLightWire(i: number) {
+      const switchWireEl = this.element.querySelector(
+        `#${getWireIdName(i, LIGHT_GROUP_CLASS_NAME)}`
+      );
+      switchWireEl.remove();
+    }
+
     private isGapClicked(pinIndex: number) {
       const gap = this.element.querySelector(
         `#${getWireIdName(pinIndex, SWITCH_GROUP_CLASS_NAME)} .clickableGap`
       );
-      return gap.getAttribute("fill") === GAP_ON_COLOR;
+      return gap.classList.contains("on");
     }
 
     private setGapClicked(pinIndex: number, isClicked: boolean) {
@@ -526,9 +540,11 @@ namespace pxsim.visuals {
         `#${getWireIdName(pinIndex, SWITCH_GROUP_CLASS_NAME)} .clickableGap`
       );
       if (isClicked) {
-        gap.setAttribute("fill", GAP_ON_COLOR);
+        gap.classList.remove("off");
+        gap.classList.add("on");
       } else {
-        gap.setAttribute("fill", GAP_OFF_COLOR);
+        gap.classList.add("off");
+        gap.classList.remove("on");
       }
     }
 

--- a/sim/visuals/chibiclip.ts
+++ b/sim/visuals/chibiclip.ts
@@ -595,6 +595,8 @@ namespace pxsim.visuals {
       const wireEl = createSwitchFromPinToVoltage(pinIndex);
       this.part.el.append(wireEl);
       this.addEventListenerForClickableSwitch(pinIndex);
+
+      this.redrawLightWiresIfNeeded(pinIndex);
     }
 
     private addEventListenerForClickableSwitch(pinIndex: number) {
@@ -645,9 +647,9 @@ namespace pxsim.visuals {
       );
     }
 
-    private redrawLightWiresIfNeeded(removedCircuitPinIndex: number) {
+    private redrawLightWiresIfNeeded(switchCircuitPinIndex: number) {
       // If a pin after me has a light
-      for (let i = removedCircuitPinIndex + 1; i < NUMBER_OF_GPIO_PINS; i++) {
+      for (let i = switchCircuitPinIndex + 1; i < NUMBER_OF_GPIO_PINS; i++) {
         const value = this.getToggleValue(i, LIGHT_GROUP_CLASS_NAME);
         if (value === ToggleValue.On) {
           this.removeCircuitForLight(i);

--- a/sim/visuals/chibiclip.ts
+++ b/sim/visuals/chibiclip.ts
@@ -55,7 +55,7 @@ const TOGGLE_WIDTH = RECT_WIDTH;
 
 const LED_TOGGLES_Y = SWITCH_TOGGLES_Y;
 const LIGHT_WIDTH = 36;
-// 
+//
 //   |\
 // a | \ c
 //   |__\
@@ -64,7 +64,9 @@ const LIGHT_WIDTH = 36;
 // a = Math.sqrt(c^2 - b^2)
 // c = LIGHT_WIDTH
 // b = LIGHT_WIDTH / 2
-const LIGHT_HEIGHT = Math.sqrt(Math.pow(LIGHT_WIDTH, 2) - Math.pow(LIGHT_WIDTH / 2, 2));
+const LIGHT_HEIGHT = Math.sqrt(
+  Math.pow(LIGHT_WIDTH, 2) - Math.pow(LIGHT_WIDTH / 2, 2)
+);
 const LIGHT_Y = CLIP_HEIGHT + SWITCH_OFF_INITIAL_WIRE_HEIGHT;
 
 const POWER_PIN_INDEX = TOTAL_NUMBER_OF_PINS - 2;
@@ -210,13 +212,11 @@ namespace pxsim.visuals {
     return labelText;
   }
 
-  function createLightTriangle(
-    pinIndex: number,
-    className: string,
-  ) {
+  function createLightTriangle(pinIndex: number, className: string) {
     const polygon = createSvgElement("polygon");
     polygon.classList.add(className);
-    const xCenterPoint = RECT_X_OFFSET + RECT_X_DISTANCE * pinIndex + RECT_WIDTH / 2;
+    const xCenterPoint =
+      RECT_X_OFFSET + RECT_X_DISTANCE * pinIndex + RECT_WIDTH / 2;
 
     const x1 = xCenterPoint - LIGHT_WIDTH / 2;
     const x2 = x1 + LIGHT_WIDTH;
@@ -250,7 +250,7 @@ namespace pxsim.visuals {
   function createSwitchFromPinToVoltage(i: number, wireHeight: number) {
     const group = createSvgElement("g");
     group.setAttribute("id", `${getWireIdName(i, SWITCH_GROUP_CLASS_NAME)}`);
-    group.classList.add("wire");
+    group.classList.add("circuit");
 
     const widthOffset = (RECT_WIDTH - WIRE_WIDTH) / 2;
     const startingX = widthOffset + RECT_X_OFFSET + RECT_X_DISTANCE * i;
@@ -312,7 +312,7 @@ namespace pxsim.visuals {
   function createLightFromPinToGround(i: number, wireHeight: number) {
     const group = createSvgElement("g");
     group.setAttribute("id", `${getWireIdName(i, LIGHT_GROUP_CLASS_NAME)}`);
-    group.classList.add("wire");
+    group.classList.add("circuit");
 
     const widthOffset = (RECT_WIDTH - WIRE_WIDTH) / 2;
     const startingX = widthOffset + RECT_X_OFFSET + RECT_X_DISTANCE * i;
@@ -352,12 +352,13 @@ namespace pxsim.visuals {
     group.append(polygon);
 
     const lightGroup = createSvgElement("g");
-    lightGroup.id = getLightIdName(i, LIGHT_GROUP_CLASS_NAME);
+    lightGroup.id = getLightIdName(i);
 
-    const lightGraphicBottom = createLightTriangle(i, 'triangle-base');
+    const lightGraphicBottom = createLightTriangle(i, "triangle-base");
     lightGroup.append(lightGraphicBottom);
 
-    const lightGraphicTop = createLightTriangle(i, 'triangle-light');
+    const lightGraphicTop = createLightTriangle(i, "triangle-light");
+    lightGraphicTop.setAttribute("fill", "transparent");
     lightGraphicTop.classList.add("off");
     lightGroup.append(lightGraphicTop);
 
@@ -393,8 +394,8 @@ namespace pxsim.visuals {
     return `${groupClassName}-wire-${pinIndex}`;
   }
 
-  function getLightIdName(pinIndex: number, groupClassName: string) {
-    return `${groupClassName}-light-${pinIndex}`;
+  function getLightIdName(pinIndex: number) {
+    return `${LIGHT_GROUP_CLASS_NAME}-light-${pinIndex}`;
   }
 
   function createToggle(
@@ -477,36 +478,24 @@ namespace pxsim.visuals {
               font-family: "Courier New";
             }
 
-            .wire {
+            .circuit {
               display: none;
             }
 
-            .wire .clickableGap.off {
+            .circuit .clickableGap.off {
               fill: transparent;
             }
 
-            .wire .clickableGap.on,
-            .wire rect, .wire polygon {
+            .circuit .clickableGap.on,
+            .circuit rect, .circuit polygon {
               fill: Silver;
             }
             
-            .wire polygon.triangle-base {
+            .circuit polygon.triangle-base {
               fill: gray;
             }
             
-            .wire polygon.triangle-light {
-              fill: white;
-              stroke: rgb(235, 235, 235);
-              stroke-width: 3;
-              stroke-miterlimit: 10;
-              filter: url("#ledGlow");
-            }
-            
-            .wire polygon.triangle-light.off {
-              display: none;
-            }
-
-            .wire.chibi-visible {
+            .circuit.chibi-visible {
               display: block;
             }
         `;
@@ -540,7 +529,7 @@ namespace pxsim.visuals {
 
       // Add switch event listeners
       const clickableGaps = this.element.querySelectorAll(
-        ".wire .clickableGap"
+        ".circuit .clickableGap"
       );
       for (const gap of clickableGaps) {
         gap.addEventListener("click", () => {
@@ -741,19 +730,17 @@ namespace pxsim.visuals {
         case ToggleValue.On:
           toggleGroup.classList.add("on");
           toggleGroup.classList.remove("disabled", "off");
-          wireEl.classList.add("chibi-visible");
+          wireEl?.classList.add("chibi-visible");
           break;
         case ToggleValue.OffAndEnabled:
           toggleGroup.classList.add("off");
           toggleGroup.classList.remove("disabled", "on");
-          wireEl.classList.remove("chibi-visible");
+          wireEl?.classList.remove("chibi-visible");
           break;
         case ToggleValue.OffAndDisabled:
           toggleGroup.classList.add("disabled");
           toggleGroup.classList.remove("off", "on");
-          if (wireEl) {
-            wireEl.classList.remove("chibi-visible");
-          }
+          wireEl?.classList.remove("chibi-visible");
       }
     }
 
@@ -812,19 +799,20 @@ namespace pxsim.visuals {
       const pinLedFillEl = this.element.querySelector(
         `#pin${index} circle.level`
       );
+      const lightEl = this.element.querySelector(`#${getLightIdName(index)} .triangle-light`);
 
       if (isOn) {
         pinFillEl.setAttribute("fill", `hsl(112.5, 100%, 67%)`); //chibineongreen
-        pinLedFillEl.setAttribute("fill", "rgb(255, 255, 255)");
-        pinLedFillEl.setAttribute("stroke", "rgb(235, 235, 235)");
-        pinLedFillEl.setAttribute("stroke-width", "3");
-        pinLedFillEl.setAttribute("stroke-miterlimit", "10");
-        pinLedFillEl.setAttribute("filter", 'url("#ledGlow")'); //chibiglow
+        this.setLedOn(pinLedFillEl, 100);
+        if (lightEl) {
+          this.setLedOn(lightEl, 100);
+        }
       } else {
         pinFillEl.setAttribute("fill", "transparent");
-        pinLedFillEl.setAttribute("fill", "transparent");
-        pinLedFillEl.removeAttribute("filter");
-        pinLedFillEl.removeAttribute("stroke");
+        this.setLedOff(pinLedFillEl);
+        if (lightEl) {
+          this.setLedOff(lightEl);
+        }
       }
     }
 
@@ -837,6 +825,7 @@ namespace pxsim.visuals {
       const pinLedFillEl = this.element.querySelector(
         `#pin${index} circle.level`
       );
+      const lightEl = this.element.querySelector(`#${getLightIdName(index)} .triangle-light`);
 
       const fillHeight = RECT_HEIGHT * percentFraction;
       pinFillEl.setAttribute("fill", "hsl(112.5, 100%, 67%)"); //chibineongreen
@@ -844,11 +833,24 @@ namespace pxsim.visuals {
       pinFillEl.setAttribute("y", `${RECT_Y + (RECT_HEIGHT - fillHeight)}`);
 
       const alpha = percentFraction;
-      pinLedFillEl.setAttribute("fill", `rgba(255, 255, 255, ${alpha})`);
-      pinLedFillEl.setAttribute("stroke", `rgb(235, 235, 235, ${alpha})`);
-      pinLedFillEl.setAttribute("stroke-width", "3");
-      pinLedFillEl.setAttribute("stroke-miterlimit", "10");
-      pinLedFillEl.setAttribute("filter", 'url("#ledGlow")'); //chibiglow
+      this.setLedOn(pinLedFillEl, alpha);
+      if (lightEl) {
+        this.setLedOn(lightEl, alpha);
+      }
+    }
+
+    private setLedOn(element: Element, alpha: number) {
+      element.setAttribute("fill", `rgba(255, 255, 255, ${alpha})`);
+      element.setAttribute("stroke", `rgb(235, 235, 235, ${alpha})`);
+      element.setAttribute("stroke-width", "3");
+      element.setAttribute("stroke-miterlimit", "10");
+      element.setAttribute("filter", 'url("#ledGlow")'); //chibiglow
+    }
+
+    private setLedOff(element: Element) {
+      element.setAttribute("fill", "transparent");
+      element.removeAttribute("filter");
+      element.removeAttribute("stroke");
     }
 
     public updateTheme(): void {}

--- a/sim/visuals/chibiclip.ts
+++ b/sim/visuals/chibiclip.ts
@@ -37,20 +37,20 @@ const TEXT_Y = RECT_Y + RECT_Y / 2;
 const TEXT_X_OFFSET = X_OFFSET;
 const TEXT_X_DISTANCE = SPACING;
 
-const WIRE_WIDTH = 20;
-const WIRE_DISTANCE = 120;
-const SWITCH_DISTANCE = 50;
-const SWITCH_GAP = 40;
+const WIRE_WIDTH = 10;
+const WIRE_DISTANCE = 90;
+const SWITCH_DISTANCE = 30;
+const SWITCH_GAP = 30;
 const WIRE_COLOR = "gray";
 const GAP_OFF_COLOR = "transparent";
 const GAP_ON_COLOR = WIRE_COLOR;
 
-const SWITCH_TOGGLES_Y = CLIP_HEIGHT + WIRE_DISTANCE + WIRE_WIDTH + 40;
+const SWITCH_TOGGLES_Y = CLIP_HEIGHT + WIRE_DISTANCE + WIRE_WIDTH + 100;
 const SWITCH_TOGGLES_GAP = 20;
 const SWITCH_TOGGLE_HEIGHT = RECT_WIDTH;
 const SWITCH_TOGGLE_WIDTH = RECT_WIDTH;
 const SWITCH_OFF_COLOR = "gainsboro";
-const SWITCH_ON_COLOR = "green";
+const SWITCH_ON_COLOR = "MediumAquamarine";
 
 const LED_TOGGLES_Y = SWITCH_TOGGLES_Y;
 
@@ -138,7 +138,7 @@ namespace pxsim.visuals {
     group.append(powerLabel);
 
     const groundPin = createPinRectangle(
-      TOTAL_NUMBER_OF_PINS - 1,
+      GROUND_PIN_INDEX,
       "ground",
       RECT_DEFAULT_FILL
     );
@@ -238,9 +238,9 @@ namespace pxsim.visuals {
     const x3 = x2;
     const y3 = y2 + (WIRE_DISTANCE - SWITCH_DISTANCE - SWITCH_GAP);
 
-    const groundPinStartingX =
-      RECT_X_OFFSET + RECT_X_DISTANCE * (TOTAL_NUMBER_OF_PINS - 1);
-    const x4 = groundPinStartingX + widthOffset;
+    const powerPinStartingX =
+      RECT_X_OFFSET + RECT_X_DISTANCE * (POWER_PIN_INDEX);
+    const x4 = powerPinStartingX + widthOffset;
     const y4 = y3;
 
     const x5 = x4;
@@ -329,6 +329,7 @@ namespace pxsim.visuals {
               font-weight: bold;
             }
 
+            .clickableGap,
             .toggle-group {
               cursor: pointer;
             }


### PR DESCRIPTION
This implements a visualization for the `when` block, and fixes the buggy implementation of the `when` block as well.

Changes:
- There's now an ability to toggle the visibility of switch wires under "Add Switch"
- When the switch wire is visible, clicking the gap in the switch will complete the circuit and light the pin in the visualizer

Fixes issue #7.
Fixes issue #8.


**BEFORE:** No visualization for `when` block.

<img width="1125" alt="CleanShot 2024-10-29 at 10 04 50@2x" src="https://github.com/user-attachments/assets/88f1a894-af93-4bef-b8e2-c79fba805ff3">

**AFTER: Has visualization for `when` block:** 

https://github.com/user-attachments/assets/9ce72cea-e5c8-4363-9bba-7404bda550c0

