### PR TITLE
Fix bug where visualization LED doesn't light after being redrawn

### DIFF
--- a/sim/visuals/chibiclip.ts
+++ b/sim/visuals/chibiclip.ts
@@ -682,9 +682,6 @@ namespace pxsim.visuals {
     private addLightCircuit(pinIndex: number) {
       this.addCircuitElementsForLight(pinIndex);
       this.setToggleValue(pinIndex, LIGHT_GROUP_CLASS_NAME, ToggleValue.On);
-
-      // Call update state to refresh the light if needed.
-      this.updateState();
     }
 
     private addCircuitElementsForLight(pinIndex: number) {
@@ -693,6 +690,9 @@ namespace pxsim.visuals {
         this.lightWireHasJump(pinIndex)
       );
       this.part.el.append(wireEl);
+
+      // Call update state to refresh the light if needed.
+      this.updateState();
     }
 
     private removeLightCircuit(pinIndex: number) {


### PR DESCRIPTION
I added the call to `this.updateState();` in the wrong location - it used to be updated only after the LED circuit was initially added, but not when it is redrawn. That meant that if you:

- Light pin 2
- Add switch to Pin 0

...the LED visualization on Pin 2 will turn off, because the line needed to be redrawn, and it will draw it in the off state

This PR fixes the issue by updating the light state every time the light circuit is drawn instead of only when initially added.