### PR TITLE
Properly model externally applied voltage

### DIFF
--- a/sim/state/edgeconnector.ts
+++ b/sim/state/edgeconnector.ts
@@ -32,7 +32,6 @@ namespace pxsim.pins {
     export let edgeConnectorSoundDisabled = false;
 
     export function digitalReadPin(pinId: number): number {
-        console.log('digital read!!!');
         let pin = getPin(pinId);
         if (!pin) return -1;
         pin.mode = PinFlags.Digital | PinFlags.Input;

--- a/sim/state/edgeconnector.ts
+++ b/sim/state/edgeconnector.ts
@@ -32,9 +32,13 @@ namespace pxsim.pins {
     export let edgeConnectorSoundDisabled = false;
 
     export function digitalReadPin(pinId: number): number {
+        console.log('digital read!!!');
         let pin = getPin(pinId);
         if (!pin) return -1;
         pin.mode = PinFlags.Digital | PinFlags.Input;
+        if (pin.isExternalVoltageApplied) {
+            return 1;
+        }
         return pin.value > 100 ? 1 : 0;
     }
 
@@ -57,6 +61,9 @@ namespace pxsim.pins {
         let pin = getPin(pinId);
         if (!pin) return -1;
         pin.mode = PinFlags.Analog | PinFlags.Input;
+        if (pin.isExternalVoltageApplied) {
+            return PIN_MAX_VALUE;
+        }
         return pin.value || 0;
     }
 

--- a/sim/state/edgeconnectorsim.ts
+++ b/sim/state/edgeconnectorsim.ts
@@ -32,7 +32,6 @@ namespace pxsim {
         servoContinuous = false;
 
         digitalReadPin(): number {
-            console.log('reading pin!!!');
             this.mode = PinFlags.Digital | PinFlags.Input;
             if (this.isExternalVoltageApplied) {
                 return 1;

--- a/sim/state/edgeconnectorsim.ts
+++ b/sim/state/edgeconnectorsim.ts
@@ -8,6 +8,8 @@ namespace pxsim {
         Touch = 0x0010
     }
 
+    export const PIN_MAX_VALUE = 1023;
+
     // Describes whether the last write an analog write, digital write, or if no write
     // has ever happened.
     export enum WriteMode {
@@ -24,12 +26,17 @@ namespace pxsim {
         servoAngle = 0;
         mode = PinFlags.Unused;
         lastWriteMode = WriteMode.NoWrite; // Added for chibi-clip visualizer
+        isExternalVoltageApplied = false; // Added for chibi-clip visualizer
         pitch = false;
         pull = 0; // PullDown
         servoContinuous = false;
 
         digitalReadPin(): number {
+            console.log('reading pin!!!');
             this.mode = PinFlags.Digital | PinFlags.Input;
+            if (this.isExternalVoltageApplied) {
+                return 1;
+            }
             return this.value > 100 ? 1 : 0;
         }
 
@@ -40,17 +47,28 @@ namespace pxsim {
             runtime.queueDisplayUpdate();
         }
 
+        addExternalVoltage() {
+            this.isExternalVoltageApplied = true;
+        }
+
+        removeExternalVoltage() {
+            this.isExternalVoltageApplied = false;
+        }
+
         setPull(pull: number) {
             this.pull = pull;
             switch(pull) {
                 case PinPullMode.PullDown: this.value = 0; break;
-                case PinPullMode.PullUp: this.value = 1023; break;
-                default: this.value = Math_.randomRange(0, 1023); break;
+                case PinPullMode.PullUp: this.value = PIN_MAX_VALUE; break;
+                default: this.value = Math_.randomRange(0, PIN_MAX_VALUE); break;
             }
         }
 
         analogReadPin(): number {
             this.mode = PinFlags.Analog | PinFlags.Input;
+            if (this.isExternalVoltageApplied) {
+                return PIN_MAX_VALUE;
+            }
             return this.value || 0;
         }
 
@@ -58,7 +76,7 @@ namespace pxsim {
             value = value >> 0;
             this.mode = PinFlags.Analog | PinFlags.Output;
             this.lastWriteMode = WriteMode.Analog;
-            this.value = Math.max(0, Math.min(1023, value));
+            this.value = Math.max(0, Math.min(PIN_MAX_VALUE, value));
             runtime.queueDisplayUpdate();
         }
 

--- a/sim/visuals/chibiclip.ts
+++ b/sim/visuals/chibiclip.ts
@@ -826,7 +826,6 @@ namespace pxsim.visuals {
 
         const isAnalog = pin.lastWriteMode === WriteMode.Analog;
         const isDigital = pin.lastWriteMode === WriteMode.Digital;
-        console.log(`pin ${i} value is ${pin.analogReadPin()}`);
         if (isAnalog) {
           this.setAnalogDisplay(i);
         } else if (isDigital) {
@@ -846,7 +845,6 @@ namespace pxsim.visuals {
       pinFillEl.setAttribute("fill", "transparent");
       pinLedFillEl.removeAttribute("stroke");
       pinLedFillEl.removeAttribute("filter");
-      console.log(`resetting pin ${index}`);
     }
 
     private setDigitalDisplay(index: number) {


### PR DESCRIPTION
Before this change, I was modeling the switch by writing 1 and 0 to the pin. This led to a bug where:
- Pin 1 is turned on via code
- Pin 1 has a switch connected to it
- Toggle the switch on pin 1 on, then off

The visualizer for Pin 1 would then show it as off, when it should actually be on still.

This PR fixes the issue by modeling the switch as an external voltage applied, which will cause reads to return 1 when applied, but doesn't actually modify the underlying value.

This PR also fixes an unrelated UI issue, where the glowing stroke was still visible after the indicator lights are turned off.