### PR TITLE
Fix bug where blink effect wasn't working for switches wired before it

### DIFF
--- a/sim/visuals/chibiclip.ts
+++ b/sim/visuals/chibiclip.ts
@@ -850,7 +850,7 @@ namespace pxsim.visuals {
 
         if (pin.isExternalVoltageApplied) {
           this.updateDigitalDisplayWithValue(i, true);
-          return;
+          continue;
         }
 
         const isAnalog = pin.lastWriteMode === WriteMode.Analog;


### PR DESCRIPTION
I believe this PR should fix this bug from the bug bash:

Bug: Blink does not work
<img width="532" alt="CleanShot 2024-11-14 at 15 43 14@2x" src="https://github.com/user-attachments/assets/651cfc62-8bb4-4ce5-8c15-4aa9519bf146">

I was accidentally returning early from the visualization during this condition, rather than skipping the pin and continuing with the visualization