### PR TITLE
Update visuals after add/remove voltage

### DIFF
--- a/sim/state/edgeconnectorsim.ts
+++ b/sim/state/edgeconnectorsim.ts
@@ -48,10 +48,12 @@ namespace pxsim {
 
         addExternalVoltage() {
             this.isExternalVoltageApplied = true;
+            runtime.queueDisplayUpdate();
         }
 
         removeExternalVoltage() {
             this.isExternalVoltageApplied = false;
+            runtime.queueDisplayUpdate();
         }
 
         setPull(pull: number) {


### PR DESCRIPTION
This fixes this bug: Toggling the switch doesn't turn off the indicator light for this case:


<img width="336" alt="CleanShot 2024-11-14 at 15 59 13@2x" src="https://github.com/user-attachments/assets/1a38be48-fc4c-4a4b-9c2f-13d61dd246ae">
