### PR TITLE
Only expose Pins 0, 1, and 2 in the interface

### DIFF
--- a/libs/core/chibiclip.ts
+++ b/libs/core/chibiclip.ts
@@ -125,7 +125,7 @@ namespace ChibiClip {
   //% block="set $pin to $on"
   //% pin.fieldEditor="textdropdown"
   //% pin.fieldOptions.decompileLiterals=true
-  //% pin.fieldOptions.values='Pin 0,Pin 1,Pin 2,Pin 3,Pin 4,Pin 5'
+  //% pin.fieldOptions.values='Pin 0,Pin 1,Pin 2'
   //% pin.defl='Pin 0'
   //% on.shadow="toggleOnOff"
   //% parts=chibiclip
@@ -150,7 +150,7 @@ namespace ChibiClip {
   //% block="set $pin level to $level"
   //% pin.fieldEditor="textdropdown"
   //% pin.fieldOptions.decompileLiterals=true
-  //% pin.fieldOptions.values='Pin 0,Pin 1,Pin 2,Pin 3,Pin 4,Pin 5'
+  //% pin.fieldOptions.values='Pin 0,Pin 1,Pin 2'
   //% pin.defl='Pin 0'
   //% level.min=0 level.max=100
   //% parts=chibiclip
@@ -181,7 +181,7 @@ namespace ChibiClip {
   //% effect.defl='blink'
   //% pin.fieldEditor="textdropdown"
   //% pin.fieldOptions.decompileLiterals=true
-  //% pin.fieldOptions.values='Pin 0,Pin 1,Pin 2,Pin 3,Pin 4,Pin 5'
+  //% pin.fieldOptions.values='Pin 0,Pin 1,Pin 2'
   //% pin.defl='Pin 0'
   //% parts=chibiclip
   //% group="Lights"
@@ -226,7 +226,7 @@ namespace ChibiClip {
   //% block="when $pin is $eventType"
   //% pin.fieldEditor="textdropdown"
   //% pin.fieldOptions.decompileLiterals=true
-  //% pin.fieldOptions.values='Pin 0,Pin 1,Pin 2,Pin 3,Pin 4,Pin 5'
+  //% pin.fieldOptions.values='Pin 0,Pin 1,Pin 2'
   //% pin.defl='Pin 0'
   //% eventType.fieldEditor="textdropdown"
   //% eventType.fieldOptions.decompileLiterals=true

--- a/sim/visuals/chibiclip.ts
+++ b/sim/visuals/chibiclip.ts
@@ -8,6 +8,7 @@ const CLIP_WIDTH = 420;
 const CLIP_HEIGHT = 120;
 
 const NUMBER_OF_GPIO_PINS = 6;
+const NUMBER_OF_USABLE_GPIO_PINS = 3; // Using only the first 3 pins for now
 const TOTAL_NUMBER_OF_PINS = NUMBER_OF_GPIO_PINS + 3; // GPIO + power + 2 grounds
 
 const ITEM_WIDTH = 30;
@@ -221,7 +222,7 @@ namespace pxsim.visuals {
     group.append(leftGroundPin);
 
     // Add gpio pins
-    for (let i = 0; i < NUMBER_OF_GPIO_PINS; i++) {
+    for (let i = 0; i < NUMBER_OF_USABLE_GPIO_PINS; i++) {
       const pinGroup = createGpioPin(i);
       group.append(pinGroup);
     }
@@ -589,7 +590,7 @@ namespace pxsim.visuals {
     labelText.innerHTML = label;
     group.append(labelText);
 
-    for (let i = 0; i < NUMBER_OF_GPIO_PINS; i++) {
+    for (let i = 0; i < NUMBER_OF_USABLE_GPIO_PINS; i++) {
       const toggle = createToggle(i, groupClassName, yOffset);
       group.append(toggle);
     }
@@ -747,7 +748,7 @@ namespace pxsim.visuals {
         return;
       }
       this.toggleState = JSON.parse(savedData);
-      for (let pinNumber = 0; pinNumber < NUMBER_OF_GPIO_PINS; pinNumber++) {
+      for (let pinNumber = 0; pinNumber < NUMBER_OF_USABLE_GPIO_PINS; pinNumber++) {
         const toggleValue = this.toggleState[pinNumber];
         // TODO: This is pretty fragile, rewrite this logic later
         switch (toggleValue) {
@@ -938,7 +939,7 @@ namespace pxsim.visuals {
 
     private redrawLightWiresIfNeeded(switchCircuitPinNumber: number) {
       // If a pin after me has a light
-      for (let i = switchCircuitPinNumber + 1; i < NUMBER_OF_GPIO_PINS; i++) {
+      for (let i = switchCircuitPinNumber + 1; i < NUMBER_OF_USABLE_GPIO_PINS; i++) {
         const value = this.getToggleValue(i, LIGHT_GROUP_CLASS_NAME);
         if (value === ToggleValue.On) {
           this.removeCircuitForLight(i);
@@ -1137,7 +1138,7 @@ namespace pxsim.visuals {
     }
 
     public updateState(): void {
-      for (let i = 0; i < NUMBER_OF_GPIO_PINS; i++) {
+      for (let i = 0; i < NUMBER_OF_USABLE_GPIO_PINS; i++) {
         const pinLoaded = this.element.querySelector(`#pin${i}`);
         if (!pinLoaded) {
           return;


### PR DESCRIPTION
Before this change, the interface showed a black bar over pins 3, 4, and 5, but these pins were still programmable.

After this change, the pins are not programmable anymore.