### PR TITLE
make switch darker gray when on

### DIFF
--- a/sim/visuals/chibiclip.ts
+++ b/sim/visuals/chibiclip.ts
@@ -686,6 +686,10 @@ namespace pxsim.visuals {
               cursor: pointer;
             }
             
+            .${CLICKABLE_SWITCH_CLASS_NAME}.on {
+              stroke: Gray;
+            }
+
             .toggle-group.off:hover .toggle,
             .toggle-group.on:hover .toggle {
               fill: gray;


### PR DESCRIPTION
Before, the switch was the same color of gray when on. Now, the switch is a darker gray when on (but the same color when off)


On:
<img width="318" alt="CleanShot 2024-11-15 at 14 37 43@2x" src="https://github.com/user-attachments/assets/9797534a-203c-40e4-b373-f77bbfe274ec">

Off:
<img width="297" alt="CleanShot 2024-11-15 at 14 38 14@2x" src="https://github.com/user-attachments/assets/a34e2ed5-54a2-4fa8-93be-4ec079a82bcc">
