### PR TITLE
Move the clip down a smidge

### DIFF
--- a/sim/visuals/chibiclip.ts
+++ b/sim/visuals/chibiclip.ts
@@ -1,8 +1,8 @@
 const ANALOG_PIN_MAX_VALUE = 1023;
 
 const CLIP_X = 38;
-const CLIP_Y = 220;
-// const CLIP_Y = 220 + 120; // for testing (lets us see the underlying pins)
+const CLIP_Y = 225;
+// const CLIP_Y = 225 + 120; // for testing (lets us see the underlying pins)
 
 const CLIP_WIDTH = 420;
 const CLIP_HEIGHT = 120;


### PR DESCRIPTION
Before, the clip would cover the tip of the last row of LEDs:
<img width="370" alt="CleanShot 2024-11-15 at 15 06 42@2x" src="https://github.com/user-attachments/assets/eb40e05d-9382-417c-87e1-6afa43e8ef5a">

Now, there's a tiny bit of space:
<img width="346" alt="CleanShot 2024-11-15 at 15 07 01@2x" src="https://github.com/user-attachments/assets/4178d5d9-ed0b-46f9-a9eb-d946e8266790">
